### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -40,17 +40,8 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
-      - name: Create release branch
+      - name: Calculate new version
         id: create-release
         env:
           HUSKY: 0
@@ -61,7 +52,7 @@ jobs:
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm run release -- --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
           git reset --hard
@@ -73,14 +64,23 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "::set-output name=source_branch_name::$source_branch_name"
           echo "::set-output name=branch_name::$branch_name"
           echo "::set-output name=new_version::$new_version"
 
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse origin/master)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
+
       - name: Update changelog & bump version
+        id: finish-release
         env:
           HUSKY: 0
         run: |
@@ -88,11 +88,19 @@ jobs:
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
           echo $SUMMARY
           echo "::set-output name=commit_summary::$SUMMARY"
-          npm run release
+          npm run release -- --skip.commit --skip.tag
 
-      - name: Push new version in release branch & tag
-        run: |
-          git push --follow-tags
+      - name: Create verified commit and tag via GitHub API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            gradle.properties
+          tag: 'v${{ steps.create-release.outputs.new_version }}'
 
       - name: Create pull request into main
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -8,10 +8,10 @@ permissions:
 
 jobs:
   draft-new-release:
-    permissions:
-      contents: write  # for Git to git push
     name: Draft a new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # GITHUB_TOKEN needs read to checkout
     if: startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/hotfix/') || startsWith(github.ref, 'refs/heads/fix/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -19,10 +19,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push changes
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -33,6 +43,8 @@ jobs:
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
       - name: Initialize mandatory git config
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
@@ -87,7 +99,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'main'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into main"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
           pr_reviewer: 'itsdebs'

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # GITHUB_TOKEN needs read to checkout
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -18,18 +20,28 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create tags and releases
+
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#hotfix-}
           VERSION=${VERSION#release/}
-          
+
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -41,8 +53,8 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npx conventional-github-releaser -p angular
 


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Implements new simplified pattern with GitHub API and signed commits

### Files Changed
- .github/workflows/notion_pr_sync.yml (GITHUB_TOKEN)
- .github/workflows/draft_new_release.yml (App Token with signed commits)
- .github/workflows/publish-new-github-release.yml (App Token)

### Migration Details
| File | Token Type | Changes |
|------|------------|---------|
| notion_pr_sync.yml | GITHUB_TOKEN | Added job-level permissions, replaced PAT with GITHUB_TOKEN |
| draft_new_release.yml | GitHub App Token | Added token generation step, job-level permissions, replaced PAT, **simplified with API-based branch creation and signed commits** |
| publish-new-github-release.yml | GitHub App Token | Added token generation step, job-level permissions, replaced PAT, fixed template injection |

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

### Simplified Pattern in draft_new_release.yml

**REMOVED (no longer needed):**
- `git config user.name/email` steps
- `git remote set-url` with token-in-URL
- `git push --set-upstream origin`
- `git push --follow-tags`
- `git add` commands
- `git commit` commands

**REPLACED WITH:**
- Create branch via GitHub API: `gh api repos/${{ github.repository }}/git/refs --method POST`
- Use `--skip.commit --skip.tag` with standard-version
- Use `ryancyq/github-signed-commit` for verified commits

### Security Improvements
- Fixed HIGH severity template injection vulnerability in publish-new-github-release.yml
- Added explicit permission blocks at job level (not workflow level)
- Token generated early before checkout
- All operations use App Token to ensure PRs trigger CI
- Verified commits via GitHub API (not git CLI)

## Test plan
- [ ] Verify notion PR sync still works after merge
- [ ] Verify draft release workflow creates PRs that trigger CI
- [ ] Verify publish release workflow creates releases successfully
- [ ] Verify commits are verified in GitHub UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)